### PR TITLE
Get OS-specific commands and args to correctly call peerflix for streami...

### DIFF
--- a/app/helpers/streams.js
+++ b/app/helpers/streams.js
@@ -1,14 +1,18 @@
 exports.create = function(self, streamURL, hostname, params) {
   var getport = require('getport');
   var request = require('request');
+  
+  var isWin = process.platform === 'win32';
 
   getport(8889, 8999, function (e, port) {
     if (e) {
       self.redirect('/');
     } else {
+      var osSpecificCommand = isWin ? 'cmd' : 'peerflix';
+      var osSpecificArgs = isWin ? ['/c', 'peerflix', decodeURIComponent(params.file),  '--port=' + port] : [decodeURIComponent(params.file),  '--port=' + port];
       var childStream = require('child')({
-        command: 'peerflix',
-        args: [decodeURIComponent(params.file),  '--port=' + port],
+        command: osSpecificCommand,
+        args: osSpecificArgs,
         cbStdout: function(data) {
           console.log(String(data));
         }


### PR DESCRIPTION
Get OS-specific commands and args to correctly call peerflix for streaming videos on Windows machines.

I added a variable to check if it's a Windows environment.  If it is, it uses 'cmd' as the command and passes '/c', 'peerflix' as arguments before passing the decoded URI and the port.  Otherwise, it reverts to the original code, calling 'peerflix' as the command and passing the decoded URI and port as arguments.

I have not tested this in Linux because I don't have a Linux machine set up with nodejs installed.
