### PR TITLE
Docker run and port  choosing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:14.04
+MAINTAINER Arthur Caranta <arthur@caranta.com>
+
+RUN apt-get update 
+RUNapt-get install -y nodejs npm nodejs-legacy
+RUN npm -g install geddy peerflix
+
+ADD . /yify-pop
+WORKDIR /yify-pop
+
+RUN npm install
+RUN npm install geddy child adm-zip getport moment opensrt_js
+
+EXPOSE 4000 8889
+
+ENV WEBPORT 4400
+ENV STREAMPORT 8889
+ENV ISDOCKER true
+
+CMD ./docker-run.sh

--- a/README.md
+++ b/README.md
@@ -31,4 +31,23 @@ Getting Started
 
 4. Visit http://localhost:4000 in your browser
 
+Running as a docker container
+-----------------------------
+1. clone this repo
+
+2. Build the image :
+```
+docker build -t yify-pop .
+```
+
+3. run it :
+```
+docker run -d -p 4000:4000 -p 8889:8889 yify-pop
+```
+
+4. if you wish to fix and change the ports :
+```
+docker run -d -e WEBPORT="7001" -e STREAMPORT="7002" -p 7001:7001 -p 7002:7002 yify-pop
+```
+
 Enjoy!

--- a/app/helpers/streams.js
+++ b/app/helpers/streams.js
@@ -8,11 +8,13 @@ exports.create = function(self, streamURL, hostname, params) {
   var _ = require('underscore');
 
   var isWin = process.platform === 'win32';
-
-  getport(8889, 8999, function (e, port) {
-    if (e) {
+  getport(geddy.config.streamport, geddy.config.streamport, function (e, port) {
+    if (e && process.env.ISDOCKER != "true") {
       self.redirect('/');
     } else {
+      if (process.env.ISDOCKER == "true") {
+        port = geddy.config.streamport
+      }
       var osSpecificCommand = isWin ? 'cmd' : 'peerflix';
       var osSpecificArgs = isWin ? ['/c', 'peerflix', decodeURIComponent(params.file),  '--port=' + port] : [decodeURIComponent(params.file),  '--port=' + port];
       var childStream = require('child')({

--- a/config/development.js
+++ b/config/development.js
@@ -22,6 +22,7 @@ var config = {
 , debug: true
 , hostname: null
 , port: 4000
+, streamport: 8889
 , model: {
     defaultAdapter: 'filesystem'
   }

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -m 
+CONFIG_FILE="config/development.js"
+
+if [ -n "${WEBPORT}" ]; then
+	/usr/bin/perl -p -i -e "s/port: 4000/port: ${WEBPORT}/g" ${CONFIG_FILE}
+fi
+
+if [ -n "${STREAMPORT}" ]; then
+	/usr/bin/perl -p -i -e "s/streamport: 8889/streamport: ${STREAMPORT}/g" ${CONFIG_FILE}
+fi
+
+geddy


### PR DESCRIPTION
Hi !

First, thanks for the work you did on this project !
Second I know that @kim0 has already created a dockerfile for this tools (https://github.com/kim0/docker-yify-pop)... which work great !

However, I wanted to include this in your project as I made several changed to the way the ports can be choosen/allocated, in order to match the user's firewall pinning.

With your configuration file it was already possible to set the web interface port (4000). However, running within a docker container, one could not change the stream port (8889). and forwarding t this port was not working.

Therefore, I added de streamport config item set to 8889 by default.
Running yify-pop normally won't change anything.
However, if ran within a docker container it uses the docker-run.sh wrapper which changed the ports int he confiugration file, sets a var to force the stream port (bypasses the getport check) and then runs yify-pop

Hope you'll like it .
;)
